### PR TITLE
Making access_logs field optional

### DIFF
--- a/modules/elb/main.tf
+++ b/modules/elb/main.tf
@@ -22,11 +22,14 @@ resource "aws_elb" "this" {
     }
   }
 
-  access_logs {
-    bucket        = lookup(var.access_logs, "bucket")
-    bucket_prefix = lookup(var.access_logs, "bucket_prefix", null)
-    interval      = lookup(var.access_logs, "interval", null)
-    enabled       = lookup(var.access_logs, "enabled", true)
+  dynamic "access_logs" {
+    for_each = var.access_logs
+    content {
+      bucket        = access_logs.value.bucket
+      bucket_prefix = lookup(access_logs.value, "bucket_prefix", null)
+      interval      = lookup(access_logs.value, "interval", null)
+      enabled       = lookup(access_logs.value, "enabled", true)
+    }
   }
 
   health_check {


### PR DESCRIPTION
# Description

There's no way not to specify `access_logs` module variable in current module version. This change simply moves `access_logs` to dynamic block. Fixes #19 