### PR TITLE
docs: Fixed ssl_certificate_id argument name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ module "elb_http" {
 
 ## Note about SSL
 
-* Valid SSL certificate has to be specified as `ssl_id_certificate` argument for secure listener. Use [terraform-aws-acm module](https://github.com/terraform-aws-modules/terraform-aws-acm) to create one. See [ELB example](https://github.com/terraform-aws-modules/terraform-aws-elb/blob/master/examples/complete/main.tf) for details.
+* Valid SSL certificate has to be specified as `ssl_certificate_id` argument for secure listener. Use [terraform-aws-acm module](https://github.com/terraform-aws-modules/terraform-aws-acm) to create one. See [ELB example](https://github.com/terraform-aws-modules/terraform-aws-elb/blob/master/examples/complete/main.tf) for details.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs


### PR DESCRIPTION
## Description
Documentation update

## Motivation and Context
Spotted wrong argument name for ssl in `README.md`

## Breaking Changes
None

## How Has This Been Tested?
No tests needed