### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/README.md
+++ b/README.md
@@ -83,19 +83,19 @@ module "elb_http" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.20 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.20 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| elb | ./modules/elb |  |
-| elb_attachment | ./modules/elb_attachment |  |
+| <a name="module_elb"></a> [elb](#module\_elb) | ./modules/elb |  |
+| <a name="module_elb_attachment"></a> [elb\_attachment](#module\_elb\_attachment) | ./modules/elb_attachment |  |
 
 ## Resources
 
@@ -105,34 +105,34 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| access\_logs | An access logs block | `map(string)` | `{}` | no |
-| connection\_draining | Boolean to enable connection draining | `bool` | `false` | no |
-| connection\_draining\_timeout | The time in seconds to allow for connections to drain | `number` | `300` | no |
-| create\_elb | Create the elb or not | `bool` | `true` | no |
-| cross\_zone\_load\_balancing | Enable cross-zone load balancing | `bool` | `true` | no |
-| health\_check | A health check block | `map(string)` | n/a | yes |
-| idle\_timeout | The time in seconds that the connection is allowed to be idle | `number` | `60` | no |
-| instances | List of instances ID to place in the ELB pool | `list(string)` | `[]` | no |
-| internal | If true, ELB will be an internal ELB | `bool` | `false` | no |
-| listener | A list of listener blocks | `list(map(string))` | n/a | yes |
-| name | The name of the ELB | `string` | `null` | no |
-| name\_prefix | The prefix name of the ELB | `string` | `null` | no |
-| number\_of\_instances | Number of instances to attach to ELB | `number` | `0` | no |
-| security\_groups | A list of security group IDs to assign to the ELB | `list(string)` | n/a | yes |
-| subnets | A list of subnet IDs to attach to the ELB | `list(string)` | n/a | yes |
-| tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| <a name="input_access_logs"></a> [access\_logs](#input\_access\_logs) | An access logs block | `map(string)` | `{}` | no |
+| <a name="input_connection_draining"></a> [connection\_draining](#input\_connection\_draining) | Boolean to enable connection draining | `bool` | `false` | no |
+| <a name="input_connection_draining_timeout"></a> [connection\_draining\_timeout](#input\_connection\_draining\_timeout) | The time in seconds to allow for connections to drain | `number` | `300` | no |
+| <a name="input_create_elb"></a> [create\_elb](#input\_create\_elb) | Create the elb or not | `bool` | `true` | no |
+| <a name="input_cross_zone_load_balancing"></a> [cross\_zone\_load\_balancing](#input\_cross\_zone\_load\_balancing) | Enable cross-zone load balancing | `bool` | `true` | no |
+| <a name="input_health_check"></a> [health\_check](#input\_health\_check) | A health check block | `map(string)` | n/a | yes |
+| <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | The time in seconds that the connection is allowed to be idle | `number` | `60` | no |
+| <a name="input_instances"></a> [instances](#input\_instances) | List of instances ID to place in the ELB pool | `list(string)` | `[]` | no |
+| <a name="input_internal"></a> [internal](#input\_internal) | If true, ELB will be an internal ELB | `bool` | `false` | no |
+| <a name="input_listener"></a> [listener](#input\_listener) | A list of listener blocks | `list(map(string))` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the ELB | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The prefix name of the ELB | `string` | `null` | no |
+| <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of instances to attach to ELB | `number` | `0` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to assign to the ELB | `list(string)` | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | A list of subnet IDs to attach to the ELB | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_elb\_arn | The ARN of the ELB |
-| this\_elb\_dns\_name | The DNS name of the ELB |
-| this\_elb\_id | The name of the ELB |
-| this\_elb\_instances | The list of instances in the ELB |
-| this\_elb\_name | The name of the ELB |
-| this\_elb\_source\_security\_group\_id | The ID of the security group that you can use as part of your inbound rules for your load balancer's back-end application instances |
-| this\_elb\_zone\_id | The canonical hosted zone ID of the ELB (to be used in a Route 53 Alias record) |
+| <a name="output_this_elb_arn"></a> [this\_elb\_arn](#output\_this\_elb\_arn) | The ARN of the ELB |
+| <a name="output_this_elb_dns_name"></a> [this\_elb\_dns\_name](#output\_this\_elb\_dns\_name) | The DNS name of the ELB |
+| <a name="output_this_elb_id"></a> [this\_elb\_id](#output\_this\_elb\_id) | The name of the ELB |
+| <a name="output_this_elb_instances"></a> [this\_elb\_instances](#output\_this\_elb\_instances) | The list of instances in the ELB |
+| <a name="output_this_elb_name"></a> [this\_elb\_name](#output\_this\_elb\_name) | The name of the ELB |
+| <a name="output_this_elb_source_security_group_id"></a> [this\_elb\_source\_security\_group\_id](#output\_this\_elb\_source\_security\_group\_id) | The ID of the security group that you can use as part of your inbound rules for your load balancer's back-end application instances |
+| <a name="output_this_elb_zone_id"></a> [this\_elb\_zone\_id](#output\_this\_elb\_zone\_id) | The canonical hosted zone ID of the ELB (to be used in a Route 53 Alias record) |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -23,52 +23,52 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.20 |
-| random | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.20 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.20 |
-| random | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.20 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| acm | terraform-aws-modules/acm/aws | ~> 2.0 |
-| ec2_instances | terraform-aws-modules/ec2-instance/aws | ~> 2.0 |
-| elb | ../../ |  |
+| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 2.0 |
+| <a name="module_ec2_instances"></a> [ec2\_instances](#module\_ec2\_instances) | terraform-aws-modules/ec2-instance/aws | ~> 2.0 |
+| <a name="module_elb"></a> [elb](#module\_elb) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_elb_service_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) |
-| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
-| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) |
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_s3_bucket.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_elb_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
+| [aws_iam_policy_document.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| number\_of\_instances | Number of instances to create and attach to ELB | `number` | `1` | no |
+| <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of instances to create and attach to ELB | `number` | `1` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_elb\_dns\_name | The DNS name of the ELB |
-| this\_elb\_id | The name of the ELB |
-| this\_elb\_instances | The list of instances in the ELB (if may be outdated, because instances are attached using elb\_attachment resource) |
-| this\_elb\_name | The name of the ELB |
-| this\_elb\_source\_security\_group\_id | The ID of the security group that you can use as part of your inbound rules for your load balancer's back-end application instances |
-| this\_elb\_zone\_id | The canonical hosted zone ID of the ELB (to be used in a Route 53 Alias record) |
+| <a name="output_this_elb_dns_name"></a> [this\_elb\_dns\_name](#output\_this\_elb\_dns\_name) | The DNS name of the ELB |
+| <a name="output_this_elb_id"></a> [this\_elb\_id](#output\_this\_elb\_id) | The name of the ELB |
+| <a name="output_this_elb_instances"></a> [this\_elb\_instances](#output\_this\_elb\_instances) | The list of instances in the ELB (if may be outdated, because instances are attached using elb\_attachment resource) |
+| <a name="output_this_elb_name"></a> [this\_elb\_name](#output\_this\_elb\_name) | The name of the ELB |
+| <a name="output_this_elb_source_security_group_id"></a> [this\_elb\_source\_security\_group\_id](#output\_this\_elb\_source\_security\_group\_id) | The ID of the security group that you can use as part of your inbound rules for your load balancer's back-end application instances |
+| <a name="output_this_elb_zone_id"></a> [this\_elb\_zone\_id](#output\_this\_elb\_zone\_id) | The canonical hosted zone ID of the ELB (to be used in a Route 53 Alias record) |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/elb/README.md
+++ b/modules/elb/README.md
@@ -5,54 +5,54 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.20 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.20 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.20 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_elb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elb) |
+| Name | Type |
+|------|------|
+| [aws_elb.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elb) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| access\_logs | An access logs block | `map(string)` | `{}` | no |
-| connection\_draining | Boolean to enable connection draining | `bool` | `false` | no |
-| connection\_draining\_timeout | The time in seconds to allow for connections to drain | `number` | `300` | no |
-| create\_elb | Create the elb or not | `bool` | `true` | no |
-| cross\_zone\_load\_balancing | Enable cross-zone load balancing | `bool` | `true` | no |
-| health\_check | A health check block | `map(string)` | n/a | yes |
-| idle\_timeout | The time in seconds that the connection is allowed to be idle | `number` | `60` | no |
-| internal | If true, ELB will be an internal ELB | `bool` | n/a | yes |
-| listener | A list of listener blocks | `list(map(string))` | n/a | yes |
-| name | The name of the ELB | `string` | `null` | no |
-| name\_prefix | The prefix name of the ELB | `string` | `null` | no |
-| security\_groups | A list of security group IDs to assign to the ELB | `list(string)` | n/a | yes |
-| subnets | A list of subnet IDs to attach to the ELB | `list(string)` | n/a | yes |
-| tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| <a name="input_access_logs"></a> [access\_logs](#input\_access\_logs) | An access logs block | `map(string)` | `{}` | no |
+| <a name="input_connection_draining"></a> [connection\_draining](#input\_connection\_draining) | Boolean to enable connection draining | `bool` | `false` | no |
+| <a name="input_connection_draining_timeout"></a> [connection\_draining\_timeout](#input\_connection\_draining\_timeout) | The time in seconds to allow for connections to drain | `number` | `300` | no |
+| <a name="input_create_elb"></a> [create\_elb](#input\_create\_elb) | Create the elb or not | `bool` | `true` | no |
+| <a name="input_cross_zone_load_balancing"></a> [cross\_zone\_load\_balancing](#input\_cross\_zone\_load\_balancing) | Enable cross-zone load balancing | `bool` | `true` | no |
+| <a name="input_health_check"></a> [health\_check](#input\_health\_check) | A health check block | `map(string)` | n/a | yes |
+| <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | The time in seconds that the connection is allowed to be idle | `number` | `60` | no |
+| <a name="input_internal"></a> [internal](#input\_internal) | If true, ELB will be an internal ELB | `bool` | n/a | yes |
+| <a name="input_listener"></a> [listener](#input\_listener) | A list of listener blocks | `list(map(string))` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the ELB | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The prefix name of the ELB | `string` | `null` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to assign to the ELB | `list(string)` | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | A list of subnet IDs to attach to the ELB | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_elb\_arn | The ARN of the ELB |
-| this\_elb\_dns\_name | The DNS name of the ELB |
-| this\_elb\_id | The name of the ELB |
-| this\_elb\_instances | The list of instances in the ELB |
-| this\_elb\_name | The name of the ELB |
-| this\_elb\_source\_security\_group | The name of the security group that you can use as part of your inbound rules for your load balancer's back-end application instances. Use this for Classic or Default VPC only. |
-| this\_elb\_source\_security\_group\_id | The ID of the security group that you can use as part of your inbound rules for your load balancer's back-end application instances. Only available on ELBs launched in a VPC. |
-| this\_elb\_zone\_id | The canonical hosted zone ID of the ELB (to be used in a Route 53 Alias record) |
+| <a name="output_this_elb_arn"></a> [this\_elb\_arn](#output\_this\_elb\_arn) | The ARN of the ELB |
+| <a name="output_this_elb_dns_name"></a> [this\_elb\_dns\_name](#output\_this\_elb\_dns\_name) | The DNS name of the ELB |
+| <a name="output_this_elb_id"></a> [this\_elb\_id](#output\_this\_elb\_id) | The name of the ELB |
+| <a name="output_this_elb_instances"></a> [this\_elb\_instances](#output\_this\_elb\_instances) | The list of instances in the ELB |
+| <a name="output_this_elb_name"></a> [this\_elb\_name](#output\_this\_elb\_name) | The name of the ELB |
+| <a name="output_this_elb_source_security_group"></a> [this\_elb\_source\_security\_group](#output\_this\_elb\_source\_security\_group) | The name of the security group that you can use as part of your inbound rules for your load balancer's back-end application instances. Use this for Classic or Default VPC only. |
+| <a name="output_this_elb_source_security_group_id"></a> [this\_elb\_source\_security\_group\_id](#output\_this\_elb\_source\_security\_group\_id) | The ID of the security group that you can use as part of your inbound rules for your load balancer's back-end application instances. Only available on ELBs launched in a VPC. |
+| <a name="output_this_elb_zone_id"></a> [this\_elb\_zone\_id](#output\_this\_elb\_zone\_id) | The canonical hosted zone ID of the ELB (to be used in a Route 53 Alias record) |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/elb_attachment/README.md
+++ b/modules/elb_attachment/README.md
@@ -5,35 +5,35 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.20 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.20 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.20 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_elb_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elb_attachment) |
+| Name | Type |
+|------|------|
+| [aws_elb_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elb_attachment) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create\_attachment | Create the elb attachment or not | `bool` | `true` | no |
-| elb | The name of the ELB | `string` | n/a | yes |
-| instances | List of instances ID to place in the ELB pool | `list(string)` | n/a | yes |
-| number\_of\_instances | Number of instances ID to place in the ELB pool | `number` | n/a | yes |
+| <a name="input_create_attachment"></a> [create\_attachment](#input\_create\_attachment) | Create the elb attachment or not | `bool` | `true` | no |
+| <a name="input_elb"></a> [elb](#input\_elb) | The name of the ELB | `string` | n/a | yes |
+| <a name="input_instances"></a> [instances](#input\_instances) | List of instances ID to place in the ELB pool | `list(string)` | n/a | yes |
+| <a name="input_number_of_instances"></a> [number\_of\_instances](#input\_number\_of\_instances) | Number of instances ID to place in the ELB pool | `number` | n/a | yes |
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
